### PR TITLE
Using arrays instead of hash for storing substitutions

### DIFF
--- a/ext/lapack/extconf.rb
+++ b/ext/lapack/extconf.rb
@@ -117,7 +117,7 @@ module FunctionDB
       cppdefs = {
          "extern" => "",  
          
-         # these are in g2c.h
+         # these are in f2c.h
          "C_f" => "void",
          "Z_f" => "void",
       }
@@ -271,8 +271,8 @@ module Main
    end
    
    def config
-      unless have_header("g2c.h") and
-            have_library("g2c") and
+      unless have_header("f2c.h") and
+#            have_library("g2c") and
             have_library("blas") and
             have_library("lapack")
          puts "A full LAPACK installation was not found."
@@ -287,7 +287,7 @@ module Main
          "rb_lapack_x.c",
       ]
 
-      $CFLAGS += ' -I.. -include g2c_typedefs.h'
+#      $CFLAGS += ' -I.. -include g2c_typedefs.h'
    end
 
    def create

--- a/ext/lapack/rb_lapack.h
+++ b/ext/lapack/rb_lapack.h
@@ -7,7 +7,7 @@
 
 #include "ruby.h"
 
-#include <g2c.h>
+#include <f2c.h>
 
 #include "include/BLAS.h"
 #include "include/LAPACK.h"

--- a/ext/linalg/dcomplex.h
+++ b/ext/linalg/dcomplex.h
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <math.h>
 
-#include <g2c.h>
+#include <f2c.h>
 
 #include "ruby.h"
 

--- a/ext/linalg/extconf.rb
+++ b/ext/linalg/extconf.rb
@@ -13,8 +13,8 @@ require 'fileutils'
 #
 ####################################################
 
-unless have_header("g2c.h") and
-      have_library("g2c") and
+unless have_header("f2c.h") and
+#      have_library("g2c") and
       have_library("blas") and
       have_library("lapack")
    puts "A full LAPACK installation was not found."
@@ -32,7 +32,7 @@ $CFLAGS += " -Wall" if CONFIG["CC"] == "gcc"
 # why doesn't $INCFLAGS work
 $CFLAGS += " -I../lapack/include"
 
-$CFLAGS += ' -I.. -include g2c_typedefs.h'
+# $CFLAGS += ' -I.. -include g2c_typedefs.h'
 
 ####################################################
 #

--- a/ext/linalg/extconf.rb
+++ b/ext/linalg/extconf.rb
@@ -50,7 +50,7 @@ module Instantiator
 
       File.open(template[:src]) { |f|
          s = f.read
-         template[:change].each_pair { |before, after|
+         template[:change].each { |before, after|
             s.gsub!(%r!#{before}!m, after)
          }
          File.open(template[:dst], "w") { |out|
@@ -71,13 +71,13 @@ end
 ####################################################
 
 module InstantiateComplex
-   change = {
-      "doublecomplex" => "complex", 
-      "dcomplex" => "scomplex",
-      "doublereal" => "real",
-      "DCOMPLEX" => "SCOMPLEX",
-      "DComplex" => "SComplex",
-   }
+   change = [
+      ["doublecomplex", "complex"] ,
+      ["dcomplex", "scomplex"],
+      ["doublereal", "real"],
+      ["DCOMPLEX", "SCOMPLEX"],
+      ["DComplex", "SComplex"]
+   ]
    
    templates = [
       {
@@ -108,77 +108,77 @@ module InstantiateXData
    templates = [
       {
          :dst => "sdata.c",
-         :change => {
-            "doublereal" => "real", 
-            "DData" => "SData",
-            "ddata" => "sdata",
-            "DDATA" => "SDATA",
-         }
+         :change => [
+            ["doublereal", "real"], 
+            ["DData", "SData"],
+            ["ddata", "sdata"],
+            ["DDATA", "SDATA"],
+         ]
       },
       
       {
          :dst => "idata.c",
-         :change => {
-            "doublereal" => "integer", 
-            "rb_float_new" => "INT2NUM",
-            "DData" => "IData",
-            "ddata" => "idata",
-            "double" => "int",
-            "NUM2DBL" => "NUM2INT",
-            "DDATA" => "IDATA"
-         }
+         :change => [
+            ["doublereal", "integer"], 
+            ["rb_float_new", "INT2NUM"],
+            ["DData", "IData"],
+            ["ddata", "idata"],
+            ["double", "int"],
+            ["NUM2DBL", "NUM2INT"],
+            ["DDATA", "IDATA"]
+         ]
       },
       
       {
          :dst => "ldata.c",
-         :change => {
-            "doublereal" => "logical", 
-            "rb_float_new" => "INT2NUM",
-            "DData" => "LData",
-            "ddata" => "ldata",
-            "double" => "int",
-            "NUM2DBL" => "NUM2INT",
-            "DDATA" => "LDATA"
-         }
+         :change => [
+            ["doublereal", "logical"], 
+            ["rb_float_new", "INT2NUM"],
+            ["DData", "LData"],
+            ["ddata", "ldata"],
+            ["double", "int"],
+            ["NUM2DBL", "NUM2INT"],
+            ["DDATA", "LDATA"]
+         ]
       },
       
       {
          :dst => "chardata.c",
-         :change => {
-            "doublereal" => "char", 
-            "rb_float_new" => "INT2NUM",
-            "DData" => "CharData",
-            "ddata" => "chardata",
-            "double" => "int",
-            "NUM2DBL" => "*StringValuePtr",
-            "DDATA" => "CHARDATA"
-         }
+         :change => [
+            ["doublereal", "char"], 
+            ["rb_float_new", "INT2NUM"],
+            ["DData", "CharData"],
+            ["ddata", "chardata"],
+            ["double", "int"],
+            ["NUM2DBL", "*StringValuePtr"],
+            ["DDATA", "CHARDATA"]
+         ]
       },
       
       {
          :dst => "zdata.c",
-         :change => {
-            "doublereal" => "doublecomplex", 
-            "rb_float_new" => "rb_dcomplex_new",
-            "DData" => "ZData",
-            "ddata" => "zdata",
-            "\\(double\\)" => "",
-            "NUM2DBL" => "rb_num2doublecomplex",
-            "DDATA" => "ZDATA"
-         }
+         :change => [
+            ["doublereal", "doublecomplex"], 
+            ["rb_float_new", "rb_dcomplex_new"],
+            ["DData", "ZData"],
+            ["ddata", "zdata"],
+            ["\\(double\\)", ""],
+            ["NUM2DBL", "rb_num2doublecomplex"],
+            ["DDATA", "ZDATA"]
+         ]
       },
       
       {
          :dst => "cdata.c",
-         :change => {
-            "doublereal" => "complex", 
-            "rb_float_new" => "rb_scomplex_new",
-            "DData" => "CData",
-            "ddata" => "cdata",
-            "\\(double\\)" => "",
-            "NUM2DBL" => "rb_num2complex",
-            "DDATA" => "CDATA"
-         }
+         :change => [
+            ["doublereal", "complex"], 
+            ["rb_float_new", "rb_scomplex_new"],
+            ["DData", "CData"],
+            ["ddata", "cdata"],
+            ["\\(double\\)", ""],
+            ["NUM2DBL", "rb_num2complex"],
+            ["DDATA", "CDATA"]
+         ]
       },
    ]
 
@@ -196,57 +196,57 @@ end
 
 module InstantiateMatrices
 
-   real = {
-      "FORTRANTYPE" => "real", 
-      "CLASSUPPER" => "SMatrix", 
-      "CLASSLOWER" => "smatrix",
-      "RUBY2FORTRAN" => "NUM2DBL",
-      "FORTRAN2RUBY" => "rb_float_new",
-      "xcopy_" => "scopy_",
-      "xgemm_" => "sgemm_",
-      "xscal_" => "sscal_",
-      "xaxpy_" => "saxpy_",
-      "xdot_" => "sdot_",
-   }
+   real = [
+      ["FORTRANTYPE", "real"], 
+      ["CLASSUPPER", "SMatrix"], 
+      ["CLASSLOWER", "smatrix"],
+      ["RUBY2FORTRAN", "NUM2DBL"],
+      ["FORTRAN2RUBY", "rb_float_new"],
+      ["xcopy_", "scopy_"],
+      ["xgemm_", "sgemm_"],
+      ["xscal_", "sscal_"],
+      ["xaxpy_", "saxpy_"],
+      ["xdot_", "sdot_"],
+   ]
    
-   doublereal = {
-      "FORTRANTYPE" => "doublereal", 
-      "CLASSUPPER" => "DMatrix", 
-      "CLASSLOWER" => "dmatrix",
-      "RUBY2FORTRAN" => "NUM2DBL",
-      "FORTRAN2RUBY" => "rb_float_new",
-      "xcopy_" => "dcopy_",
-      "xgemm_" => "dgemm_",
-      "xscal_" => "dscal_",
-      "xaxpy_" => "daxpy_",
-      "xdot_" => "ddot_",
-   }
+   doublereal = [
+      ["FORTRANTYPE", "doublereal"], 
+      ["CLASSUPPER", "DMatrix"], 
+      ["CLASSLOWER", "dmatrix"],
+      ["RUBY2FORTRAN", "NUM2DBL"],
+      ["FORTRAN2RUBY", "rb_float_new"],
+      ["xcopy_", "dcopy_"],
+      ["xgemm_", "dgemm_"],
+      ["xscal_", "dscal_"],
+      ["xaxpy_", "daxpy_"],
+      ["xdot_", "ddot_"],
+   ]
    
-   complex = {
-      "FORTRANTYPE" => "complex", 
-      "CLASSUPPER" => "CMatrix", 
-      "CLASSLOWER" => "cmatrix",
-      "RUBY2FORTRAN" => "rb_num2complex",
-      "FORTRAN2RUBY" => "rb_scomplex_new",
-      "xcopy_" => "ccopy_",
-      "xgemm_" => "cgemm_",
-      "xscal_" => "cscal_",
-      "xaxpy_" => "caxpy_",
-      "xdotc_" => "cdotc_",
-   }
+   complex = [
+      ["FORTRANTYPE", "complex"], 
+      ["CLASSUPPER", "CMatrix"], 
+      ["CLASSLOWER", "cmatrix"],
+      ["RUBY2FORTRAN", "rb_num2complex"],
+      ["FORTRAN2RUBY", "rb_scomplex_new"],
+      ["xcopy_", "ccopy_"],
+      ["xgemm_", "cgemm_"],
+      ["xscal_", "cscal_"],
+      ["xaxpy_", "caxpy_"],
+      ["xdotc_", "cdotc_"],
+   ]
    
-   doublecomplex = {
-      "FORTRANTYPE" => "doublecomplex", 
-      "CLASSUPPER" => "ZMatrix", 
-      "CLASSLOWER" => "zmatrix",
-      "RUBY2FORTRAN" => "rb_num2doublecomplex",
-      "FORTRAN2RUBY" => "rb_dcomplex_new",
-      "xcopy_" => "zcopy_",
-      "xgemm_" => "zgemm_",
-      "xscal_" => "zscal_",
-      "xaxpy_" => "zaxpy_",
-      "xdotc_" => "zdotc_",
-   }
+   doublecomplex = [
+      ["FORTRANTYPE", "doublecomplex"], 
+      ["CLASSUPPER", "ZMatrix"], 
+      ["CLASSLOWER", "zmatrix"],
+      ["RUBY2FORTRAN", "rb_num2doublecomplex"],
+      ["FORTRAN2RUBY", "rb_dcomplex_new"],
+      ["xcopy_", "zcopy_"],
+      ["xgemm_", "zgemm_"],
+      ["xscal_", "zscal_"],
+      ["xaxpy_", "zaxpy_"],
+      ["xdotc_", "zdotc_"],
+   ]
    
    templates = [
       {

--- a/ext/linalg/xdata.h
+++ b/ext/linalg/xdata.h
@@ -10,7 +10,7 @@
 
 #include "ruby.h"
 
-#include <g2c.h>
+#include <f2c.h>
 
 #include "linalg.h"
 #include "dcomplex.h"

--- a/ext/linalg/xmatrix.h.tmpl
+++ b/ext/linalg/xmatrix.h.tmpl
@@ -12,7 +12,7 @@
 #include <math.h>
 #include <time.h>
 
-#include <g2c.h>
+#include <f2c.h>
 
 #include "BLAS.h"
 #include "LAPACK.h"


### PR DESCRIPTION
Order of text-substitutions must be preserved, otherwise replacing 'double' with 'int' and later 'doublereal' with something results in 'intreal'.
